### PR TITLE
Add articles section to _pkgdown.yml

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,6 +6,21 @@ template:
 development:
   mode: auto
 
+articles:
+  - title: "Getting started"
+    navbar: ~
+    contents:
+      - database-connect
+  - title: "Camera traps"
+    navbar: Camera traps
+    contents:
+      - camtrap-upload
+      - data-download
+  - title: "Transects"
+    navbar: Transects
+    contents:
+      - transect-upload
+
 reference:
   - title: "Database connection"
     desc: >


### PR DESCRIPTION
Groups vignettes into Camera traps and Transects sections in the navbar so they are discoverable on the pkgdown site.